### PR TITLE
fix: escape frontmatter title to prevent build error

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ dist
 dist-ssr
 out
 pnpm-lock.yaml
+src/content/docs/api*

--- a/example/astro.multiple-entrypoints.config.ts
+++ b/example/astro.multiple-entrypoints.config.ts
@@ -10,6 +10,9 @@ const typeDocSidebarGroup = await generateTypeDoc({
     collapsed: true,
   },
   tsconfig: '../fixtures/tsconfig.json',
+  typeDoc: {
+    readme: undefined,
+  },
 })
 
 export default defineConfig({

--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "starlight-typedoc-fixtures",
+  "name": "@starlight-typedoc/fixtures",
   "version": "0.0.1",
   "license": "MIT",
   "description": "Astro integration for Starlight to generate documentation from TypeScript using TypeDoc.",

--- a/packages/starlight-typedoc/src/libs/typedoc.ts
+++ b/packages/starlight-typedoc/src/libs/typedoc.ts
@@ -62,7 +62,8 @@ function onRendererPageEnd(event: PageEvent<DeclarationReflection>, pagination: 
     editUrl: false,
     next: pagination,
     prev: pagination,
-    title: event.model.name,
+    // Wrap in quotes to prevent issue with special characters in frontmatter
+    title: `"${event.model.name}"`,
   })
 }
 


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

Wraps the frontmatter title in double quotes

**Why**

If the title contains special characters (such as `@` in my case) then rendering will fail as this is considered invalid syntax.

**How**

Using string literal with double quotes, not sure if this is the most flexible for any future issues or not (such as double-wrapped quotes).

**Screenshots**

N/A
<!-- Feel free to add additional comments. -->
