### PR TITLE
Fix: Change order that configs are applied

### DIFF
--- a/packages/starlight-typedoc/src/libs/typedoc.ts
+++ b/packages/starlight-typedoc/src/libs/typedoc.ts
@@ -20,7 +20,6 @@ const markdownPluginConfig: TypeDocConfig = {
   hideKindPrefix: true,
   hidePageHeader: true,
   hidePageTitle: true,
-  skipIndexPage: true,
 }
 
 export async function bootstrapApp(

--- a/packages/starlight-typedoc/src/libs/typedoc.ts
+++ b/packages/starlight-typedoc/src/libs/typedoc.ts
@@ -20,6 +20,7 @@ const markdownPluginConfig: TypeDocConfig = {
   hideKindPrefix: true,
   hidePageHeader: true,
   hidePageTitle: true,
+  skipIndexPage: true,
 }
 
 export async function bootstrapApp(

--- a/packages/starlight-typedoc/src/libs/typedoc.ts
+++ b/packages/starlight-typedoc/src/libs/typedoc.ts
@@ -40,8 +40,8 @@ export async function bootstrapApp(
 
   await app.bootstrapWithPlugins({
     ...defaultTypeDocConfig,
-    ...config,
     ...getMarkdownPluginConfig(outputDirectory),
+    ...config,
     entryPoints,
     tsconfig,
   })

--- a/packages/starlight-typedoc/tests/unit/typedoc.test.ts
+++ b/packages/starlight-typedoc/tests/unit/typedoc.test.ts
@@ -91,3 +91,20 @@ test('should not add `README.md` module files for multiple entry points', async 
   expect(writeFileSyncSpy).toHaveBeenCalled()
   expect(filePaths.some((filePath) => filePath.endsWith('README.md'))).toBe(false)
 })
+
+test('should support overriding typedoc-plugin-markdown readme and index page generation', async () => {
+  await generateTypeDoc({
+    ...starlightTypeDocOptions,
+    typeDoc: {
+      readme: undefined,
+      skipIndexPage: false,
+    },
+    entryPoints: ['../../fixtures/src/Bar.ts', '../../fixtures/src/Foo.ts'],
+  })
+
+  const writeFileSyncSpy = vi.mocked(fs.writeFileSync)
+  const filePaths = writeFileSyncSpy.mock.calls.map((call) => call[0].toString())
+
+  expect(filePaths.some((filePath) => filePath.endsWith('API.md'))).toBe(true)
+  expect(filePaths.some((filePath) => filePath.endsWith('README.md'))).toBe(true)
+})

--- a/packages/starlight-typedoc/tests/unit/typedoc.test.ts
+++ b/packages/starlight-typedoc/tests/unit/typedoc.test.ts
@@ -79,7 +79,7 @@ test('should generate the doc in a custom output directory relative to `src/cont
   expect(mkdirSyncSpy.mock.calls[0]?.[0].toString().endsWith(`src/content/docs/${output}`)).toBe(true)
 })
 
-test('should add `README.md` module files for multiple entry points', async () => {
+test('should not add `README.md` module files for multiple entry points', async () => {
   await generateTypeDoc({
     ...starlightTypeDocOptions,
     entryPoints: ['../../fixtures/src/Bar.ts', '../../fixtures/src/Foo.ts'],
@@ -89,5 +89,5 @@ test('should add `README.md` module files for multiple entry points', async () =
   const filePaths = writeFileSyncSpy.mock.calls.map((call) => call[0].toString())
 
   expect(writeFileSyncSpy).toHaveBeenCalled()
-  expect(filePaths.some((filePath) => filePath.endsWith('README.md'))).toBe(true)
+  expect(filePaths.some((filePath) => filePath.endsWith('README.md'))).toBe(false)
 })

--- a/packages/starlight-typedoc/tests/unit/typedoc.test.ts
+++ b/packages/starlight-typedoc/tests/unit/typedoc.test.ts
@@ -96,7 +96,7 @@ test('should support overriding typedoc-plugin-markdown readme and index page ge
   await generateTypeDoc({
     ...starlightTypeDocOptions,
     typeDoc: {
-      readme: undefined,
+      readme: 'README.md',
       skipIndexPage: false,
     },
     entryPoints: ['../../fixtures/src/Bar.ts', '../../fixtures/src/Foo.ts'],

--- a/packages/starlight-typedoc/tests/unit/typedoc.test.ts
+++ b/packages/starlight-typedoc/tests/unit/typedoc.test.ts
@@ -79,7 +79,7 @@ test('should generate the doc in a custom output directory relative to `src/cont
   expect(mkdirSyncSpy.mock.calls[0]?.[0].toString().endsWith(`src/content/docs/${output}`)).toBe(true)
 })
 
-test('should not add `README.md` module files for multiple entry points', async () => {
+test('should add `README.md` module files for multiple entry points', async () => {
   await generateTypeDoc({
     ...starlightTypeDocOptions,
     entryPoints: ['../../fixtures/src/Bar.ts', '../../fixtures/src/Foo.ts'],
@@ -89,5 +89,5 @@ test('should not add `README.md` module files for multiple entry points', async 
   const filePaths = writeFileSyncSpy.mock.calls.map((call) => call[0].toString())
 
   expect(writeFileSyncSpy).toHaveBeenCalled()
-  expect(filePaths.some((filePath) => filePath.endsWith('README.md'))).toBe(false)
+  expect(filePaths.some((filePath) => filePath.endsWith('README.md'))).toBe(true)
 })


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

With `skipIndexPage` explicitly set it's impossible to create an index page with a single entry point that exports other modules/namespaces:

https://github.com/tgreyuk/typedoc-plugin-markdown/blob/next/packages/typedoc-plugin-markdown/docs/usage/options.md#skipindexpage

**Why**

Can't generate index pages with this being explicitly set

**How**

Remove the explicit setting of `skipIndexPage`

**Screenshots**

N/A

<!-- Feel free to add additional comments. -->

I remember you mentioning on Discord that your usage explicitly disables this so this could be a bit of a breaking change technically.