### PR TITLE
feat!: add support for TypeDoc v0.25 which is now the minimum supported version

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -19,7 +19,7 @@
     "@astrojs/starlight": "0.5.0",
     "astro": "2.5.5",
     "starlight-typedoc": "workspace:*",
-    "typedoc": "0.24.8",
+    "typedoc": "0.25",
     "typedoc-plugin-markdown": "4.0.0-next.16",
     "typedoc-plugin-mdn-links": "3.0.3"
   },

--- a/packages/starlight-typedoc/package.json
+++ b/packages/starlight-typedoc/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@astrojs/starlight": ">=0.5.0",
-    "typedoc": ">=0.24.0",
+    "typedoc": ">=0.25.0",
     "typedoc-plugin-markdown": ">=4.0.0-next.14"
   },
   "engines": {

--- a/packages/starlight-typedoc/src/index.ts
+++ b/packages/starlight-typedoc/src/index.ts
@@ -15,7 +15,7 @@ export async function generateTypeDoc(options: StarlightTypeDocOptions): Promise
     outputDirectory,
     options.pagination ?? false
   )
-  const reflections = app.convert()
+  const reflections = await app.convert()
 
   if (!reflections?.groups || reflections.groups.length === 0) {
     throw new Error('Failed to generate TypeDoc documentation.')

--- a/packages/starlight-typedoc/src/libs/theme.ts
+++ b/packages/starlight-typedoc/src/libs/theme.ts
@@ -52,7 +52,7 @@ class StarlightTypeDocThemeRenderContext extends MarkdownThemeRenderContext {
   override comment: (comment: Comment, headingLevel?: number | undefined) => string = (comment, headingLevel) => {
     const filteredComment = { ...comment } as Comment
     filteredComment.blockTags = []
-    filteredComment.modifierTags = new Set<string>()
+    filteredComment.modifierTags = new Set<`@${string}`>()
 
     const customTags: CustomTag[] = []
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -45,14 +45,14 @@ importers:
         specifier: workspace:*
         version: link:../packages/starlight-typedoc
       typedoc:
-        specifier: 0.24.8
-        version: 0.24.8(typescript@5.1.6)
+        specifier: '0.25'
+        version: 0.25.0(typescript@5.1.6)
       typedoc-plugin-markdown:
         specifier: 4.0.0-next.16
-        version: 4.0.0-next.16(prettier@2.8.8)(typedoc@0.24.8)
+        version: 4.0.0-next.16(prettier@2.8.8)(typedoc@0.25.0)
       typedoc-plugin-mdn-links:
         specifier: 3.0.3
-        version: 3.0.3(typedoc@0.24.8)
+        version: 3.0.3(typedoc@0.25.0)
 
   fixtures:
     dependencies:
@@ -72,11 +72,11 @@ importers:
         specifier: 4.1.5
         version: 4.1.5
       typedoc:
-        specifier: '>=0.24.0'
-        version: 0.24.8(typescript@5.1.6)
+        specifier: '>=0.25.0'
+        version: 0.25.0(typescript@5.1.6)
       typedoc-plugin-markdown:
         specifier: '>=4.0.0-next.14'
-        version: 4.0.0-next.14(prettier@2.8.8)(typedoc@0.24.8)
+        version: 4.0.0-next.14(prettier@2.8.8)(typedoc@0.25.0)
     devDependencies:
       '@playwright/test':
         specifier: 1.35.0
@@ -4587,8 +4587,8 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
-  /minimatch@9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
     dependencies:
       brace-expansion: 2.0.1
@@ -5988,44 +5988,44 @@ packages:
       is-typed-array: 1.1.10
     dev: true
 
-  /typedoc-plugin-markdown@4.0.0-next.14(prettier@2.8.8)(typedoc@0.24.8):
+  /typedoc-plugin-markdown@4.0.0-next.14(prettier@2.8.8)(typedoc@0.25.0):
     resolution: {integrity: sha512-mmmSjuwtZCKOcwaHmWxoaOwFp0Jwaqc25KIz/87MPcyRtBhg1d0ivEFyMaDA49jI9xRceef8ISe2UdkaQsnhuQ==}
     peerDependencies:
       prettier: '>=1.8.0'
       typedoc: '>=0.24.0'
     dependencies:
       prettier: 2.8.8
-      typedoc: 0.24.8(typescript@5.1.6)
+      typedoc: 0.25.0(typescript@5.1.6)
     dev: false
 
-  /typedoc-plugin-markdown@4.0.0-next.16(prettier@2.8.8)(typedoc@0.24.8):
+  /typedoc-plugin-markdown@4.0.0-next.16(prettier@2.8.8)(typedoc@0.25.0):
     resolution: {integrity: sha512-+ut3u62pZ+/L1vpoofOGm44ByZOWPCsgSxIm5VssLUuQSrP2jwNceB8AE7bZqp5wvNvZ7i7/6oXNZrKWRlHmeA==}
     peerDependencies:
       prettier: '>=1.8.0'
       typedoc: '>=0.24.0'
     dependencies:
       prettier: 2.8.8
-      typedoc: 0.24.8(typescript@5.1.6)
+      typedoc: 0.25.0(typescript@5.1.6)
     dev: false
 
-  /typedoc-plugin-mdn-links@3.0.3(typedoc@0.24.8):
+  /typedoc-plugin-mdn-links@3.0.3(typedoc@0.25.0):
     resolution: {integrity: sha512-NXhIpwQnsg7BcyMCHVqj3tUK+DL4g3Bt96JbFl4APzTGFkA+iM6GfZ/fn3TAqJ8O0CXG5R9BfWxolw1m1omNuQ==}
     peerDependencies:
       typedoc: '>= 0.23.14 || 0.24.x'
     dependencies:
-      typedoc: 0.24.8(typescript@5.1.6)
+      typedoc: 0.25.0(typescript@5.1.6)
     dev: false
 
-  /typedoc@0.24.8(typescript@5.1.6):
-    resolution: {integrity: sha512-ahJ6Cpcvxwaxfu4KtjA8qZNqS43wYt6JL27wYiIgl1vd38WW/KWX11YuAeZhuz9v+ttrutSsgK+XO1CjL1kA3w==}
-    engines: {node: '>= 14.14'}
+  /typedoc@0.25.0(typescript@5.1.6):
+    resolution: {integrity: sha512-FvCYWhO1n5jACE0C32qg6b3dSfQ8f2VzExnnRboowHtqUD6ARzM2r8YJeZFYXhcm2hI4C2oCRDgNPk/yaQUN9g==}
+    engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.1.6
+      typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.1.6
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 9.0.1
+      minimatch: 9.0.3
       shiki: 0.14.2
       typescript: 5.1.6
     dev: false


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

**Describe the pull request**

From what I can see other plugins in the ecosystem are doing, this is the preferred way to initialise plugins. I believe this does require typedoc 0.25 in order to work as `Application.bootstrapWithPlugins()` was private before.

**Why**

Without this new users would have a crash on a new install that defaults to typedoc 0.25

**How**

N/A

<!-- Feel free to add additional comments. -->

I'm not exactly how you'd like to maintain versioning on this. Typedoc 0.24 to 0.25 are technical breaking changes. Looking at the other packages here: https://typedoc.org/guides/plugins/#0.25.0, it seems that anything that has a released major is doing this as a minor bump, anything that doesn't have a v1 major (so this package as well) did it as a patch bump. 