### PR TITLE
Fix compatibility with `typedoc-plugin-markdown` version `4.0.0-next.59`

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -56,7 +56,7 @@ ni starlight-typedoc typedoc typedoc-plugin-markdown@next
 </Tabs>
 
 :::note
-The Starlight TypeDoc package requires at least the version `4.0.0-next.54` of `typedoc-plugin-markdown`, hence the `@next` tag in the installation command.
+The Starlight TypeDoc package requires at least the version `4.0.0-next.59` of `typedoc-plugin-markdown`, hence the `@next` tag in the installation command.
 :::
 
 ## Add the plugin

--- a/example/package.json
+++ b/example/package.json
@@ -23,7 +23,7 @@
     "sharp": "0.32.6",
     "starlight-typedoc": "workspace:*",
     "typedoc": "0.25",
-    "typedoc-plugin-markdown": "4.0.0-next.54",
+    "typedoc-plugin-markdown": "4.0.0-next.59",
     "typedoc-plugin-mdn-links": "3.0.3"
   },
   "engines": {

--- a/packages/starlight-typedoc/libs/theme.ts
+++ b/packages/starlight-typedoc/libs/theme.ts
@@ -8,7 +8,7 @@ import {
   type PageEvent,
   type CommentDisplayPart,
 } from 'typedoc'
-import { MarkdownTheme, MarkdownThemeRenderContext } from 'typedoc-plugin-markdown'
+import { MarkdownTheme, MarkdownThemeContext } from 'typedoc-plugin-markdown'
 
 import { getAsideMarkdown, getRelativeURL } from './starlight'
 
@@ -21,27 +21,23 @@ export class StarlightTypeDocTheme extends MarkdownTheme {
   }
 }
 
-class StarlightTypeDocThemeRenderContext extends MarkdownThemeRenderContext {
-  #markdownThemeRenderContext: MarkdownThemeRenderContext
+class StarlightTypeDocThemeRenderContext extends MarkdownThemeContext {
+  #markdownThemeContext: MarkdownThemeContext
 
   constructor(theme: MarkdownTheme, event: PageEvent<Reflection>, options: Options) {
     super(theme, event, options)
 
-    this.#markdownThemeRenderContext = new MarkdownThemeRenderContext(theme, event, options)
+    this.#markdownThemeContext = new MarkdownThemeContext(theme, event, options)
   }
 
-  override helpers: MarkdownThemeRenderContext['helpers'] = {
-    // @ts-expect-error https://github.com/tgreyuk/typedoc-plugin-markdown/blob/2bc4136a364c1d1ab44789d6148cd19c425ce63c/docs/pages/docs/customizing-output.mdx#custom-theme
-    ...this.helpers,
-    getRelativeUrl: (url: string) => {
-      const outputDirectory = this.options.getValue('starlight-typedoc-output')
-      const baseUrl = typeof outputDirectory === 'string' ? outputDirectory : ''
+  override getRelativeUrl(url: string): string {
+    const outputDirectory = this.options.getValue('starlight-typedoc-output')
+    const baseUrl = typeof outputDirectory === 'string' ? outputDirectory : ''
 
-      return getRelativeURL(url, baseUrl, this.page.url)
-    },
+    return getRelativeURL(url, baseUrl, this.page.url)
   }
 
-  override partials: MarkdownThemeRenderContext['partials'] = {
+  override partials: MarkdownThemeContext['partials'] = {
     // @ts-expect-error https://github.com/tgreyuk/typedoc-plugin-markdown/blob/2bc4136a364c1d1ab44789d6148cd19c425ce63c/docs/pages/docs/customizing-output.mdx#custom-theme
     ...this.partials,
     comment: (comment, options) => {
@@ -70,7 +66,7 @@ class StarlightTypeDocThemeRenderContext extends MarkdownThemeRenderContext {
 
       filteredComment.summary = comment.summary.map((part) => this.#parseCommentDisplayPart(part))
 
-      let markdown = this.#markdownThemeRenderContext.partials.comment(filteredComment, options)
+      let markdown = this.#markdownThemeContext.partials.comment(filteredComment, options)
 
       if (options?.showSummary === false) {
         return markdown
@@ -110,7 +106,7 @@ class StarlightTypeDocThemeRenderContext extends MarkdownThemeRenderContext {
     ) {
       return {
         ...part,
-        target: this.helpers.getRelativeUrl(
+        target: this.getRelativeUrl(
           path.posix.join(this.options.getValue('entryPointStrategy') === 'packages' ? '../..' : '..', part.target.url),
         ),
       }

--- a/packages/starlight-typedoc/libs/typedoc.ts
+++ b/packages/starlight-typedoc/libs/typedoc.ts
@@ -29,7 +29,6 @@ const defaultTypeDocConfig: TypeDocConfig = {
 
 const markdownPluginConfig: TypeDocConfig = {
   hideBreadcrumbs: true,
-  hideInPageTOC: true,
   hidePageHeader: true,
   hidePageTitle: true,
 }
@@ -88,6 +87,7 @@ async function bootstrapApp(
   })
   app.logger = new StarlightTypeDocLogger(logger)
   app.options.addReader(new TSConfigReader())
+  // @ts-expect-error - Invalid theme typing
   app.renderer.defineTheme('starlight-typedoc', StarlightTypeDocTheme)
   app.renderer.on(PageEvent.END, (event: PageEvent<DeclarationReflection>) => {
     onRendererPageEnd(event, pagination)

--- a/packages/starlight-typedoc/package.json
+++ b/packages/starlight-typedoc/package.json
@@ -37,7 +37,7 @@
     "@astrojs/starlight": ">=0.15.0",
     "astro": ">=4.0.0",
     "typedoc": ">=0.25.0",
-    "typedoc-plugin-markdown": ">=4.0.0-next.54"
+    "typedoc-plugin-markdown": ">=4.0.0-next.59"
   },
   "engines": {
     "node": ">=18.14.1"

--- a/packages/starlight-typedoc/tests/e2e/basics/content.test.ts
+++ b/packages/starlight-typedoc/tests/e2e/basics/content.test.ts
@@ -65,7 +65,7 @@ test('should disable edit links', async ({ docPage }) => {
 test('should support TypeDoc plugins', async ({ docPage }) => {
   await docPage.goto('classes/foo')
 
-  const mdnLink = docPage.page.getByRole('link', { exact: true, name: 'HTMLElement' })
+  const mdnLink = docPage.page.getByRole('link', { exact: true, name: 'HTMLElement ↗️' })
 
   await expect(mdnLink).toBeVisible()
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: '0.25'
         version: 0.25.0(typescript@5.1.6)
       typedoc-plugin-markdown:
-        specifier: 4.0.0-next.54
-        version: 4.0.0-next.54(typedoc@0.25.0)
+        specifier: 4.0.0-next.59
+        version: 4.0.0-next.59(typedoc@0.25.0)
       typedoc-plugin-mdn-links:
         specifier: 3.0.3
         version: 3.0.3(typedoc@0.25.0)
@@ -90,8 +90,8 @@ importers:
         specifier: '>=0.25.0'
         version: 0.25.0(typescript@5.1.6)
       typedoc-plugin-markdown:
-        specifier: '>=4.0.0-next.54'
-        version: 4.0.0-next.54(typedoc@0.25.0)
+        specifier: '>=4.0.0-next.59'
+        version: 4.0.0-next.59(typedoc@0.25.0)
     devDependencies:
       '@astrojs/starlight':
         specifier: 0.15.1
@@ -5952,8 +5952,8 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typedoc-plugin-markdown@4.0.0-next.54(typedoc@0.25.0):
-    resolution: {integrity: sha512-Irb0AxXqRZCpXAcZpGGb3pqG4SP0DzT3Q88rI3ak4K37rJ4jgfNOf/jCTHhD/B2iFty9DKNlssia2ytXDdCOSA==}
+  /typedoc-plugin-markdown@4.0.0-next.59(typedoc@0.25.0):
+    resolution: {integrity: sha512-UXnC5xnsGAd4ZIG7LsEh3RESWMy0ve9eDC+51Ql1B0D5byVp++aPonUzqSNGZylim+ee+OgSdrqx0mfnsXBLIQ==}
     peerDependencies:
       typedoc: 0.25.x
     dependencies:


### PR DESCRIPTION
Closes #42 