### PR TITLE
fix: fixes generation issue with the Astro `srcDir` option

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
         with:
           version: 8.6.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
         with:
           version: 8.6.1
 

--- a/packages/starlight-typedoc/index.ts
+++ b/packages/starlight-typedoc/index.ts
@@ -24,7 +24,7 @@ function makeStarlightTypeDocPlugin(sidebarGroup: SidebarGroup): (options: Starl
       name: 'starlight-typedoc-plugin',
       hooks: {
         async setup({ astroConfig, config, logger, updateConfig }) {
-          const { outputDirectory, reflections } = await generateTypeDoc(options, astroConfig.base, logger)
+          const { outputDirectory, reflections } = await generateTypeDoc(options, astroConfig, logger)
           const sidebar = getSidebarFromReflections(
             config.sidebar,
             sidebarGroup,

--- a/packages/starlight-typedoc/libs/typedoc.ts
+++ b/packages/starlight-typedoc/libs/typedoc.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { AstroIntegrationLogger } from 'astro'
+import type { AstroConfig, AstroIntegrationLogger } from 'astro'
 import {
   Application,
   PageEvent,
@@ -35,7 +35,11 @@ const markdownPluginConfig: TypeDocConfig = {
   hidePageTitle: true,
 }
 
-export async function generateTypeDoc(options: StarlightTypeDocOptions, base: string, logger: AstroIntegrationLogger) {
+export async function generateTypeDoc(
+  options: StarlightTypeDocOptions,
+  config: AstroConfig,
+  logger: AstroIntegrationLogger,
+) {
   const outputDirectory = options.output ?? 'api'
 
   const app = await bootstrapApp(
@@ -44,7 +48,7 @@ export async function generateTypeDoc(options: StarlightTypeDocOptions, base: st
     options.typeDoc,
     outputDirectory,
     options.pagination ?? false,
-    base,
+    config.base,
     logger,
   )
   const reflections = await app.convert()
@@ -56,7 +60,7 @@ export async function generateTypeDoc(options: StarlightTypeDocOptions, base: st
     throw new Error('Failed to generate TypeDoc documentation.')
   }
 
-  const outputPath = path.join('src/content/docs', outputDirectory)
+  const outputPath = path.join(`${config.srcDir.pathname}/content/docs`, outputDirectory)
 
   if (options.watch) {
     app.convertAndWatch(async (reflections) => {

--- a/packages/starlight-typedoc/libs/typedoc.ts
+++ b/packages/starlight-typedoc/libs/typedoc.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import url from 'node:url'
 
 import type { AstroConfig, AstroIntegrationLogger } from 'astro'
 import {
@@ -60,7 +61,7 @@ export async function generateTypeDoc(
     throw new Error('Failed to generate TypeDoc documentation.')
   }
 
-  const outputPath = path.join(`${config.srcDir.pathname}/content/docs`, outputDirectory)
+  const outputPath = path.join(url.fileURLToPath(config.srcDir), 'content/docs', outputDirectory)
 
   if (options.watch) {
     app.convertAndWatch(async (reflections) => {

--- a/packages/starlight-typedoc/tests/unit/typedoc.test.ts
+++ b/packages/starlight-typedoc/tests/unit/typedoc.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 
-import type { AstroIntegrationLogger } from 'astro'
+import type { AstroIntegrationLogger, AstroConfig } from 'astro'
 import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest'
 
 import type { StarlightTypeDocOptions } from '../..'
@@ -12,6 +12,11 @@ const starlightTypeDocOptions = {
     logLevel: 4,
   },
 } satisfies Partial<StarlightTypeDocOptions>
+
+const starlightTypeDocAstroConfig: Partial<AstroConfig> = {
+  // './src' is the default value supplied by Astro — https://docs.astro.build/en/reference/configuration-reference/#srcdir
+  srcDir: new URL('src', import.meta.url),
+}
 
 beforeAll(() => {
   vi.spyOn(fs, 'mkdirSync').mockReturnValue(undefined)
@@ -65,6 +70,21 @@ test('should generate the doc in `src/content/docs/api` by default', async () =>
 
   expect(mkdirSyncSpy).toHaveBeenCalled()
   expect(mkdirSyncSpy.mock.calls[0]?.[0].toString()).toMatch(/src[/\\]content[/\\]docs[/\\]api$/)
+})
+
+test('should generate the doc in `/content/docs/api` of the srcDir via the AstroConfig', async () => {
+  await generateTestTypeDoc(
+    {
+      ...starlightTypeDocOptions,
+      entryPoints: ['../../fixtures/basics/src/functions.ts'],
+    },
+    { srcDir: new URL('docs/src', import.meta.url) } as AstroConfig,
+  )
+
+  const mkdirSyncSpy = vi.mocked(fs.mkdirSync)
+
+  expect(mkdirSyncSpy).toHaveBeenCalled()
+  expect(mkdirSyncSpy.mock.calls[0]?.[0].toString()).toMatch(/docs[/\\]src[/\\]content[/\\]docs[/\\]api$/)
 })
 
 test('should generate the doc in a custom output directory relative to `src/content/docs/`', async () => {
@@ -165,13 +185,16 @@ test('should output index with correct module path', async () => {
   ).toBe(true)
 })
 
-function generateTestTypeDoc(options: Parameters<typeof generateTypeDoc>[0]) {
+function generateTestTypeDoc(
+  options: Parameters<typeof generateTypeDoc>[0],
+  config: AstroConfig = starlightTypeDocAstroConfig as AstroConfig,
+) {
   return generateTypeDoc(
     {
       ...starlightTypeDocOptions,
       ...options,
     },
-    '/',
+    config,
     {
       info() {
         // noop

--- a/packages/starlight-typedoc/tests/unit/typedoc.test.ts
+++ b/packages/starlight-typedoc/tests/unit/typedoc.test.ts
@@ -78,13 +78,13 @@ test('should generate the doc in `/content/docs/api` of the srcDir via the Astro
       ...starlightTypeDocOptions,
       entryPoints: ['../../fixtures/basics/src/functions.ts'],
     },
-    { srcDir: new URL('docs/src', import.meta.url) } as AstroConfig,
+    { srcDir: new URL('www/src', import.meta.url) },
   )
 
   const mkdirSyncSpy = vi.mocked(fs.mkdirSync)
 
   expect(mkdirSyncSpy).toHaveBeenCalled()
-  expect(mkdirSyncSpy.mock.calls[0]?.[0].toString()).toMatch(/docs[/\\]src[/\\]content[/\\]docs[/\\]api$/)
+  expect(mkdirSyncSpy.mock.calls[0]?.[0].toString()).toMatch(/www[/\\]src[/\\]content[/\\]docs[/\\]api$/)
 })
 
 test('should generate the doc in a custom output directory relative to `src/content/docs/`', async () => {
@@ -187,14 +187,14 @@ test('should output index with correct module path', async () => {
 
 function generateTestTypeDoc(
   options: Parameters<typeof generateTypeDoc>[0],
-  config: AstroConfig = starlightTypeDocAstroConfig as AstroConfig,
+  config: Partial<AstroConfig> = starlightTypeDocAstroConfig,
 ) {
   return generateTypeDoc(
     {
       ...starlightTypeDocOptions,
       ...options,
     },
-    config,
+    config as AstroConfig,
     {
       info() {
         // noop


### PR DESCRIPTION
<!---
Thanks for submitting a pull request 😄 !
Please provide as much details as possible, including screenshots or sample code if necessary.
-->

First, I just found this tool and it's fantastic! Thanks for all the hard work.

**Describe the pull request**

Adds support for respecting the [`srcDir`](https://docs.astro.build/en/reference/configuration-reference/#srcdir) option from the Astro Config

**Why**

I have a lib that I work on and the docs are in the repo like this:

```
.
├── CHANGELOG.md
├── CONTRIBUTING.md
├── LICENSE.md
├── README.md
├── changelog.sh
├── dist
├── docs (the source of the docs)
├── node_modules
├── package-lock.json
├── package.json
├── src (the library source)
└── test
```

and my `docs/astro.config.mjs` looks like this:

```js
import { defineConfig } from "astro/config";
import starlight from "@astrojs/starlight";
import starlightTypeDoc, { typeDocSidebarGroup } from "starlight-typedoc";

// https://astro.build/config
export default defineConfig({
  root: "./docs",
  srcDir: "./docs/src",
  integrations: [
    starlight({
      plugins: [
        starlightTypeDoc({
          entryPoints: ["./src/index.ts"],
          tsconfig: "./.config/tsconfig.json"
        })
      ],
      sidebar: [
        {
          label: "Getting started",
          autogenerate: { directory: "getting-started" }
        },
        // Add the generated sidebar group to the sidebar.
        typeDocSidebarGroup
      ]
    })
  ]
});
```

This was causing `starlight-typedoc` to generate the markdown files in `src` (the library source) and not in `docs/src` the `srcDir` in the config.

**How**

The changes were implemented primarily by passing in the whole `AstroConfig` to `generateTypeDoc` function, and updating the `outputPath`:

```diff
- const outputPath = path.join('src/content/docs', outputDirectory)
+ const outputPath = path.join(`${config.srcDir.pathname}/content/docs`, outputDirectory)
```

**Additional comments**

(1) I've never used workspaces, and the changes in `pnpm-lock` are confusing to me. Let me know if I should revert those changes
(2) I feel...eh about the tests, but I wasn't sure if there was a better way to fake the `AstroConfig`. 