### PR TITLE
add i18n support

### DIFF
--- a/packages/starlight-typedoc/index.ts
+++ b/packages/starlight-typedoc/index.ts
@@ -24,15 +24,14 @@ function makeStarlightTypeDocPlugin(sidebarGroup: SidebarGroup): (options: Starl
       name: 'starlight-typedoc-plugin',
       hooks: {
         async setup({ astroConfig, config, logger, updateConfig }) {
-          const { outputDirectory, reflections } = await generateTypeDoc(options, astroConfig, logger)
+          const { baseOutputDirectory, reflections } = await generateTypeDoc(options, astroConfig, logger)
           const sidebar = getSidebarFromReflections(
             config.sidebar,
             sidebarGroup,
             options.sidebar,
             reflections,
-            outputDirectory,
+            baseOutputDirectory,
           )
-
           updateConfig({ sidebar })
         },
       },
@@ -60,6 +59,11 @@ export interface StarlightTypeDocOptions {
    * @default false
    */
   pagination?: boolean
+  /**
+   * The locale where the documentation should be generated. For example, if you pass 'en', the documentation will be generated
+   * relative to `src/content/docs/en/`
+   */
+  locale?: string
   /**
    * The path to the `tsconfig.json` file to use for the documentation generation.
    */

--- a/packages/starlight-typedoc/libs/starlight.ts
+++ b/packages/starlight-typedoc/libs/starlight.ts
@@ -120,7 +120,7 @@ function getSidebarGroupFromReflections(
 
             return getSidebarGroupFromReflections(
               { collapsed: true, label: child.name },
-              child,
+              child as DeclarationReflection,
               baseOutputDirectory,
               `${outputDirectory}/${isParentKindModule ? url.dir.split('/').slice(1).join('/') : url.dir}`,
             )

--- a/packages/starlight-typedoc/libs/typedoc.ts
+++ b/packages/starlight-typedoc/libs/typedoc.ts
@@ -41,7 +41,8 @@ export async function generateTypeDoc(
   config: AstroConfig,
   logger: AstroIntegrationLogger,
 ) {
-  const outputDirectory = options.output ?? 'api'
+  const baseOutputDirectory = options.output ?? 'api'
+  const outputDirectory = options.locale ? `${options.locale}/${baseOutputDirectory}` : baseOutputDirectory
 
   const app = await bootstrapApp(
     options.entryPoints,
@@ -71,7 +72,7 @@ export async function generateTypeDoc(
     await app.generateDocs(reflections, outputPath)
   }
 
-  return { outputDirectory, reflections }
+  return { baseOutputDirectory, outputDirectory, reflections }
 }
 
 async function bootstrapApp(
@@ -96,6 +97,7 @@ async function bootstrapApp(
   })
   app.logger = new StarlightTypeDocLogger(logger)
   app.options.addReader(new TSConfigReader())
+  // @ts-expect-error - Type 'new (renderer: Renderer) => StarlightTypeDocTheme' is not assignable to type 'new (renderer: Renderer) => Theme'
   app.renderer.defineTheme('starlight-typedoc', StarlightTypeDocTheme)
   app.renderer.on(PageEvent.BEGIN, (event: PageEvent<Reflection>) => {
     onRendererPageBegin(event, pagination)


### PR DESCRIPTION
**Describe the pull request**

I added support for an additional option `locale`. If this is specified, then the docs will be generated in the specified locale (e.g., `src/content/docs/en/`), otherwise the plugin behaves as before.

**Why**

When you specify [additional languages in starlight](https://starlight.astro.build/guides/i18n/) the generates docs need to be in the localized directory, but the auto generate path for the sidebar should not include the locale. Previously, the plugin did not support this use case.

**How**

I added a locale option. If this is specified, then the typedoc output will add the locale as the prefix. It returns the output directory without the prefix for the sidebar.

**Additional Comments**

Let me know if there is a preferred way to do this and I can change it. This is just what was easiest to do without making significant changes as an outsider.
